### PR TITLE
Add HAQQ Legal AI to Commercial AI Research Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ Browser-based platforms and search engines for case law, statutes, and dockets.
 - [Paxton AI](https://paxton.ai) - **[AI-Native]** Jurisdiction-aware AI legal answers.
 - [EvenUp](https://evenuplaw.com) - **[AI-Native]** Agentic demand letter generation and research for personal injury.
 - [Lexlegis.AI](https://lexlegis.ai) - **[AI-Native]** Indian legal research LLM trained on 10M+ documents.
+- [HAQQ Legal AI](https://haqq.ai) - **[AI-Native]** Bilingual Arabic/English legal research, contract review, and case law search for MENA jurisdictions (Lebanon, GCC, Egypt).
 - [Blue J](https://bluej.com) - **[AI-Native]** AI-powered answers to complex US/Canada/UK tax questions.
 - [Bloomberg Law](https://pro.bloomberglaw.com) - **[Established]** Major US legal research platform with AI brief analysis and real-time legislative monitoring.
 - [vLex / Vincent AI](https://vlex.com) - **[Established]** Global coverage (1B+ documents, 17 countries) with cross-jurisdictional AI comparison.


### PR DESCRIPTION
Adds HAQQ Legal AI — a bilingual (Arabic/English) legal research and contract review platform for MENA jurisdictions (Lebanon, GCC, Egypt).

The current list has excellent coverage of US, UK, EU, Indian, and Chinese legal AI, but no Arabic-first legal AI tools. HAQQ Legal AI fills that regional gap and is in production with law firms across Lebanon, Saudi Arabia, the UAE, and Egypt.

- Site: https://haqq.ai
- Category: Commercial AI Research Platforms (AI-Native)
- Entry placed alphabetically after Lexlegis.AI (other regional-focused AI-Native entry)