### PR TITLE
Add Prest0 to Full-Stack Legal Platforms & Suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Comprehensive platforms that handle multiple functions across the legal workflow
 - [Legora](https://legora.com) - **[AI-Native]** YC-backed collaborative AI workspace spanning research, drafting, and review.
 - [Eudia](https://eudia.com) - **[AI-Native]** AI agents specifically designed for Fortune 500 in-house corporate legal teams.
 - [DeepJudge](https://deepjudge.ai) - **[AI-Native]** Custom AI workflows applied directly to internal law firm knowledge bases.
+- [Prest0](https://prest0.ai) - **[AI-Native]** Enterprise bilingual (English/Spanish) legal AI platform that deploys a dedicated AI agent per law firm on an isolated VM with persistent memory, Twilio voice + SMS intake, deep research, and legal-grade document drafting — purpose-built for immigration, workers' compensation, and employment law.
 
 ---
 


### PR DESCRIPTION
Hi! Submitting Prest0 for the **Full-Stack Legal Platforms & Suites** section.

**Prest0** (https://prest0.ai) is an enterprise legal AI platform that deploys a dedicated bilingual (English/Spanish) AI agent per law firm — each on an isolated VM with persistent memory, Twilio voice + SMS intake, deep legal research, and legal-grade document drafting.

### Why this fits the list
- **AI-native** — built ground-up for legal workflows, not a generic chatbot wrapper.
- **Full-stack** — spans voice intake, SMS, research, drafting, and case memory on a per-firm VM.
- **Vertical specialization** — purpose-built for immigration (I-589 asylum, U-visa), California workers' comp (WCAB Pre-Hearing Statements under Rule 10563), and plaintiff-side employment law.
- **Bilingual** — Spanish-first for client-facing flows, a gap most US legaltech ignores.

### Differentiator
Patent-pending **Context-Based Semantic TreeSearch** memory architecture — a tree-traversal retrieval layer that replaces flat-vector RAG for long-horizon agent memory.

### Formatting
Matches the existing `- [Name](url) - **[Tag]** Description.` style. Placed alphabetically-adjacent in the AI-Native cluster.

Thanks for maintaining this list!