### PR TITLE
Add AI Laws by State (50-state AI legislation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ Browser-based platforms and search engines for case law, statutes, and dockets.
 - [GovInfo](https://www.govinfo.gov) - US federal legislation, regulations, and congressional records. Bulk data/API available.
 - [eCFR](https://www.ecfr.gov) - Up-to-date Code of Federal Regulations with a full bulk API.
 - [OpenStates](https://openstates.org) - Open-source platform tracking US state legislation in real time.
+- [AI Laws by State](https://www.ailawsbystate.com) - Free 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits).
 - [Google Scholar Case Law](https://scholar.google.com) - Free US federal and state court opinions.
 
 #### United Kingdom


### PR DESCRIPTION
This adds [AI Laws by State](https://www.ailawsbystate.com), a free 50-state tracker for U.S. AI legislation that covers:

- Bill status, effective dates, and penalty structures across all 50 states
- Topic-specific trackers (deepfakes, hiring, healthcare AI, disclosure, bias audits)
- Primary-source linked — every entry cites the official state legislature URL
- Free tier covers state pages, bill detail, and basic search; Pro tier for CSV exports, alerts, comparison tools, and full historical data

Fits in the **United States** section under *Open / Free Access (By Jurisdiction)* because it is an open public-interest tracker for U.S. AI legislation — similar in spirit to OpenStates but focused specifically on AI bills across all 50 states.

Happy to adjust formatting or section placement to match your conventions.