### PR TITLE
Add Clarvia to Access to Justice section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ Organizations and software actively using technology to advance access to justic
 - [Clear My Record (Code for America)](https://www.clearmyrecord.org/) - **[Nonprofit]** Code for America initiative powering automatic record-sealing/expungement; helped reduce or dismiss 144,000 California cannabis convictions.
 - [World Justice Project Rule of Law Index](https://worldjusticeproject.org/rule-of-law-index/) - **[Nonprofit]** Annual data series measuring rule of law across 143 jurisdictions (95% of world population).
 - [HiiL (Hague Institute for Innovation of Law)](https://www.hiil.org/) - **[Nonprofit]** Justice Accelerator (110+ startups funded since 2011), Justice Innovation Labs, and people-centred justice research.
+- [Clarvia](https://github.com/clarvia-org/clarvia-graph) - **[Open Source]** Free, open-source bereavement compliance checklist for European families. Source-backed legal deadlines, multilingual, structured as a knowledge graph.
 
 ## Foundational Research
 


### PR DESCRIPTION
Adds [Clarvia](https://github.com/clarvia-org/clarvia-graph) to the **Access to Justice & Public Interest Tech** section.

Clarvia is a free, open-source bereavement compliance checklist for European families. It provides source-backed legal deadlines structured as a knowledge graph, helping families navigate after-death admin across European jurisdictions.

- **Website**: https://clarvia.org
- **Repository**: https://github.com/clarvia-org/clarvia-graph
- **License**: Open source
- **Tags**: civic-tech, legal-tech, open-data, multilingual, europe, typescript