### PR TITLE
Add Lien Deadlines (free US mechanics-lien-deadline reference) to Legal Research Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ Direct links to canonical government legal-data sources for jurisdictions where 
 - [eCFR](https://www.ecfr.gov) - Up-to-date Code of Federal Regulations with a full bulk API.
 - [OpenStates](https://openstates.org) - Open-source platform tracking US state legislation in real time.
 - [AI Laws by State](https://www.ailawsbystate.com) - Free 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits).
+- [Lien Deadlines](https://ipythoning.github.io/lien-deadlines/) - Free statute-cited reference and calculator for US mechanics/construction lien deadlines (CA, TX, FL) by claimant role, with an open CC BY 4.0 dataset in JSON and CSV.
 - [Google Scholar Case Law](https://scholar.google.com) - Free US federal and state court opinions.
 
 #### United Kingdom


### PR DESCRIPTION
## What

Adds one entry under **Legal Research Platforms → Open / Free Access (By Jurisdiction) → United States**, next to the existing free statutory tracker *AI Laws by State*:

> [Lien Deadlines](https://ipythoning.github.io/lien-deadlines/) - Free statute-cited reference and calculator for US mechanics/construction lien deadlines (CA, TX, FL) by claimant role, with an open CC BY 4.0 dataset in JSON and CSV.

## Why it belongs

- **Open / free-access US statutory reference**, same category as the adjacent *AI Laws by State* entry (free per-state statutory tracker).
- **Verifiable & active**: live site (last verified 2026-06-10), public repo, machine-readable CC BY 4.0 dataset.
  - Live: https://ipythoning.github.io/lien-deadlines/
  - Repo: https://github.com/iPythoning/lien-deadlines
  - Dataset: https://ipythoning.github.io/lien-deadlines/data/deadlines.json
- **Unique**: no existing entry covers mechanics-lien deadlines.

## Scope note

Coverage is currently 3 states (CA/TX/FL) by claimant role; it is an informational reference with prominent disclaimers (not legal advice). Description kept neutral/one-sentence per CONTRIBUTING.md.