### PR TITLE
Add Sound Suite to MCP Servers for Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Domain-specific encoder models for legal text similarity, classification, and re
 - [French Law MCP](https://github.com/Ansvar-Systems/French-law-mcp) - **[🇫🇷 France]** MCP exposing 3,958 French statutes (Code civil, Code pénal, Code du travail, Code de commerce, Loi I&L) verified against official sources.
 - [SEC EDGAR MCP](https://github.com/stefanoamorelli/sec-edgar-mcp) - **[🇺🇸 US]** MCP for SEC EDGAR filings, financial statements, and insider-trading data — useful for securities and corporate-disclosure workflows.
 - [mcp-cerebra-legal-server](https://github.com/yoda-digital/mcp-cerebra-legal-server) - MCP providing structured legal-reasoning tools (`legal_think`, follow-up, completion) with domain templates for contract, consumer-protection, and French procurement analysis.
+- [Sound Suite](https://github.com/alperu/soundsuite) - **[Self-Hosted]** Local-first legal document intelligence platform exposing 14 MCP tools (semantic and keyword/hybrid search, OCR, exhibit image retrieval, and case-knowledge queries); watches case-file directories and indexes PDFs into a local vector store, running entirely on-premises with no external API calls. Source-available under the Polyform Noncommercial license.
 
 > **Note:** MCP for legal is an emerging ecosystem. Many servers are early-stage community projects. Always verify data accuracy and jurisdiction coverage before use in legal practice.
 


### PR DESCRIPTION
## What

Adds **[Sound Suite](https://github.com/alperu/soundsuite)** to the **MCP Servers for Legal** section.

## Why it belongs

- **Unique technical approach** — a local-first, fully self-hosted legal document-intelligence platform that exposes its capabilities as MCP tools (semantic + keyword/hybrid search, OCR, exhibit image retrieval, case-knowledge queries). It watches case-file directories and indexes PDFs into a local vector store, running entirely on-premises with no external API calls — distinct from the API-wrapper MCP servers already listed.
- **Public repo with meaningful code** — https://github.com/alperu/soundsuite (public).
- **Actively maintained** — v1.0.2 released this week.
- **Verifiable** — website https://soundsuite.ai and public GitHub repo.

## Notes for maintainers

- License is **source-available (Polyform Noncommercial)** — not an OSI-approved license. Flagged explicitly in the entry; included on the basis of the distinct technical approach + public, buildable codebase, consistent with this list's coverage of non-OSS platforms.
- Description kept neutral/factual per CONTRIBUTING (no promotional language), em-dash separator, placed in the MCP section.