### PR TITLE
Add TrustYourWebsite to Compliance & RegTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Sphere](https://www.getsphere.com/) - **[AI-Native]** AI-native cross-border indirect tax (sales tax, VAT, GST) compliance engine serving Deel, Replit, and Lovable; $21M Series A led by a16z (Nov 2025).
 - [Climate Case Chart](https://www.climatecasechart.com/) - **[Open / Academic]** Sabin Center + Arnold & Porter database of 2,600+ US and global climate-change cases across 54 jurisdictions, updated monthly.
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
+- [TrustYourWebsite](https://trustyourwebsite.com) - **[🇪🇺 EU]** Automated website-level compliance scanner (GDPR, cookie consent, accessibility, legal pages) for EU and UK small businesses; free scan returns a risk score and issue counts.
 
 ---
 


### PR DESCRIPTION
Adds TrustYourWebsite to the Compliance & RegTech section.

**What it is:** an automated website-level compliance scanner for EU and UK small businesses. It checks a public website for GDPR issues, cookie-consent implementation (CMP detection, cookie classification, third-party trackers), accessibility (axe-core), and required legal pages, and returns a risk score with itemised findings. The free tier scans any site and returns the risk score plus issue counts; paid reports add full findings and remediation guidance.

**Why it belongs (inclusion criteria):**
- *Unique technical approach within the category:* the existing Compliance & RegTech entries are org-level GRC/process platforms (Drata, Vanta, OneTrust, ComplyAdvantage). There is currently no website-level outside-in compliance scanner in the section; this fills that gap with a deterministic scan (DOM/HTTP checks, axe-core) rather than questionnaire-driven GRC workflows.
- *Regional representation:* built for the EU/UK small-business segment, covering 9 EU markets plus the UK in 5 languages, a geography/segment not otherwise represented in this section.

Formatting matches the existing entries (one-sentence neutral description, EU tag as used elsewhere in the list).

**Disclosure:** I'm the author of the tool. Happy to adjust wording, tag, or placement, or to withdraw if the maintainers feel it does not meet the curation bar.