### PR TITLE
Add Superhighway - regulatory research agent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Sphere](https://www.getsphere.com/) - **[AI-Native]** AI-native cross-border indirect tax (sales tax, VAT, GST) compliance engine serving Deel, Replit, and Lovable; $21M Series A led by a16z (Nov 2025).
 - [Climate Case Chart](https://www.climatecasechart.com/) - **[Open / Academic]** Sabin Center + Arnold & Porter database of 2,600+ US and global climate-change cases across 54 jurisdictions, updated monthly.
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
+- [Superhighway](https://superhighway.walls.sh/guides/regulatory-research-agent) - **[AI-Native]** Pay-per-call web search API for building regulatory research agents; live-web search/scrape/research endpoints produce structured compliance briefs covering requirements, enforcement actions, and penalty exposure, distinct from the static GRC databases in this category.
 
 ---
 


### PR DESCRIPTION
Adds Superhighway to the **Compliance & RegTech** section. Superhighway is an AI-native, pay-per-call web search API for building regulatory research agents — its live /search, /scrape, /research, and /news endpoints produce structured compliance briefs covering requirements, recent enforcement actions, and penalty exposure.

**Why it belongs (unique technical approach):** unlike the static GRC platforms and databases already in this category (Drata, Vanta, OneTrust, etc.), Superhighway grounds compliance research in live web search at query time, so agents surface the latest rule changes and enforcement actions rather than a pre-indexed corpus. It is a real, publicly accessible developer API (no signup, pay-per-call), not a landing page. The linked page is the runnable Python build guide for the agent. https://superhighway.walls.sh/guides/regulatory-research-agent