### PR TITLE
Add deslop to Document Automation & Drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ Software for generating, assembling, and reviewing legal documents.
 - [Suffolk LIT Lab Assembly Line](https://github.com/SuffolkLITLab/docassemble-AssemblyLine) - **[Open Source]** Toolkit for Massachusetts court forms; reusable pattern for any jurisdiction.
 - [open-agreements](https://github.com/CommonAccord/Cmacc-Org) - **[Open Source]** CommonAccord: legal documents as structured, linkable data.
 - [adeu](https://github.com/dealfluence/adeu) - **[Open Source]** Agentic DOCX Redlining Engine for Word document Track Changes.
+- [deslop](https://github.com/fayerman-source/deslop) - **[Open Source]** Portable AI agent skill that rewrites legalese into plain English while preserving binding terms of art.
 
 - [Spellbook](https://spellbook.legal) - **[AI-Native]** AI contract drafting and review assistant operating natively in Microsoft Word.
 - [Clearbrief](https://clearbrief.com) - **[AI-Native]** AI-powered factual verification and drafting assistance in briefs.


### PR DESCRIPTION
Adds **deslop** under Document Automation & Drafting (Open Source group).

- **Link:** https://github.com/fayerman-source/deslop
- **Inclusion criterion:** Open source (public repo, MIT) with a distinct approach: a portable agent `SKILL.md` that rewrites legalese into plain English while preserving binding legal terms of art. Not duplicated by any existing entry.
- **Maintained:** Yes (active, public).
- **Described neutrally**, no promotional language.

Format matches the existing `- [Name](url) - **[Open Source]** description.` style in that section.