### PR TITLE
Add Aricase to Consumer Legal Services (B2C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1091,7 +1091,7 @@ Platforms delivering direct-to-consumer automated legal services, documents, and
 - [Trust & Will](https://trustandwill.com/) - **[Established]** Largest US consumer estate-planning platform with attorney-network and AI features; raised $25M+ Series C (March 2025).
 - [Wealth.com](https://www.wealth.com/) - **[AI-Native]** Estate-planning platform for RIAs/wirehouses with "Ester" AI doc extraction; underpins wealth managers running >$15T AUM.
 - [SoloSuit](https://www.solosuit.com/) - **[AI-Native]** "TurboTax for debt-collection lawsuits" — auto-drafts answers and runs SoloSettle negotiations; has helped 350,000+ Americans protect $2.5B+ in debt.
-- [Aricase](https://aricase.ai) - **[AI-Native]** Employment-tribunal case-builder: guidance, document drafting and next steps, with a human quality check.
+- [Aricase](https://aricase.ai) - **[AI-Native]** 🇬🇧 Employment-tribunal case-builder (England & Wales): guidance, document drafting and next steps, with a human quality check.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1091,6 +1091,7 @@ Platforms delivering direct-to-consumer automated legal services, documents, and
 - [Trust & Will](https://trustandwill.com/) - **[Established]** Largest US consumer estate-planning platform with attorney-network and AI features; raised $25M+ Series C (March 2025).
 - [Wealth.com](https://www.wealth.com/) - **[AI-Native]** Estate-planning platform for RIAs/wirehouses with "Ester" AI doc extraction; underpins wealth managers running >$15T AUM.
 - [SoloSuit](https://www.solosuit.com/) - **[AI-Native]** "TurboTax for debt-collection lawsuits" — auto-drafts answers and runs SoloSettle negotiations; has helped 350,000+ Americans protect $2.5B+ in debt.
+- [Aricase](https://aricase.ai) - **[AI-Native]** Employment-tribunal case-builder: guidance, document drafting and next steps, with a human quality check.
 
 ---
 


### PR DESCRIPTION
Adds Aricase to Consumer Legal Services (B2C): an employment-tribunal case-builder that guides a claimant through their case, drafts the documents, and maps next steps, with a human review step. AI-Native and actively maintained. Live at https://aricase.ai.