### PR TITLE
Add AI Law Radar MCP (AI-regulation tracker) to MCP Servers for Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Domain-specific encoder models for legal text similarity, classification, and re
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers that connect AI assistants to legal data sources and workflows.
 
 - [Vaquill AI MCP](https://github.com/vaquill-AI/vaquill-mcp) - MCP server that connects Claude / Cursor / Windsurf / VS Code to 8M+ US federal and state court opinions plus the US Code and CFR. *(Sponsor)*
+- [AI Law Radar MCP](https://ailawradar.com/api) - MCP server that lets AI assistants (Claude, Cursor) query a live, primary-sourced register of AI-regulation obligations and deadlines across 13 jurisdictions; returns facts + official source URLs. Free; also a REST API + open data (CC BY 4.0).
 - [CourtListener MCP (DefendTheDisabled)](https://github.com/DefendTheDisabled/courtlistener-mcp) - Connects AI agents to CourtListener with semantic search, hybrid search, and citation verification to mitigate hallucination.
 - [CourtListener MCP (Travis-Prall)](https://github.com/Travis-Prall/court-listener-mcp) - MCP Server for accessing CourtListener case data, court opinions, and eCFR federal regulations.
 - [CourtListener MCP (khizar-anjum)](https://github.com/khizar-anjum/courtlistener-mcp) - MCP server built for searching cases by natural language legal problems across 3,352 U.S. courts.


### PR DESCRIPTION
Adds [AI Law Radar](https://ailawradar.com) — a free, open (CC BY 4.0) tracker of AI-law obligations and deadlines across 13 jurisdictions, with an MCP server (`/api/mcp`) so AI assistants can query live AI-regulation facts + official sources, plus a REST API. Re-verified daily; not legal advice. Fills a gap in this section (AI-regulation, vs the existing case-law/contract MCP servers). Thanks for maintaining this list!