### PR TITLE
Add MiCAR Whitepaper Linter to Compliance & RegTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Climate Case Chart](https://www.climatecasechart.com/) - **[Open / Academic]** Sabin Center + Arnold & Porter database of 2,600+ US and global climate-change cases across 54 jurisdictions, updated monthly.
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
 - [TrustYourWebsite](https://trustyourwebsite.com) - **[🇪🇺 EU]** Automated website-level compliance scanner (GDPR, cookie consent, accessibility, legal pages) for EU and UK small businesses; free scan returns a risk score and issue counts.
+- [MiCAR Whitepaper Linter](https://github.com/sebastianfoerste/micar-whitepaper-linter) - **[🇪🇺 EU]** Deterministic linter for crypto-asset white papers under MiCAR (EU) 2023/1114: 35 rules mapped to Annex I-III with pinpoint citations and cited review reports.
 
 ---
 


### PR DESCRIPTION
Adds [micar-whitepaper-linter](https://github.com/sebastianfoerste/micar-whitepaper-linter) to **Compliance & RegTech**.

**What it is:** a deterministic Python linter for crypto-asset white paper drafts under MiCAR (Regulation (EU) 2023/1114). 35 rules mapped to Annex I, II and III with stable rule IDs and pinpoint citations; outputs cited findings, remediation reports, and review bundles. Synthetic examples only; explicitly not legal advice.

**Inclusion criteria mapping:**
- *Unique technical approach* — to my knowledge the only public regulation-as-code linter for MiCAR white papers; every finding carries a pinpoint Annex citation rather than a generic completeness score.
- *Regional representation* — EU crypto-asset regulation (MiCAR), not otherwise covered in this section.
- *Minimum bar* — actively maintained (commits this week), factually verifiable (public repo, runnable via `make install && make test && make demo`), v0.1.0 tagged, CI + 54 passing tests, committed example outputs.

**Disclosure:** I am the author — a German-qualified lawyer practicing EU financial regulation; the rule-to-Annex mapping is hand-authored. Happy to reword the description or move the entry if you see a better fit.