### PR TITLE
Add Get Up to Code (US compliance scanner) to Compliance & RegTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Climate Case Chart](https://www.climatecasechart.com/) - **[Open / Academic]** Sabin Center + Arnold & Porter database of 2,600+ US and global climate-change cases across 54 jurisdictions, updated monthly.
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
 - [TrustYourWebsite](https://trustyourwebsite.com) - **[🇪🇺 EU]** Automated website-level compliance scanner (GDPR, cookie consent, accessibility, legal pages) for EU and UK small businesses; free scan returns a risk score and issue counts.
+- [Get Up to Code](https://getuptocode.com) - **[🇺🇸 US]** Automated website-level compliance scanner (ADA/WCAG accessibility, CCPA and US state privacy, FTC rules, security headers, image copyright) for US small businesses; free scan returns a risk score, $5 full report.
 
 ---
 


### PR DESCRIPTION
Adds **Get Up to Code** to `## Compliance & RegTech`, matching the section's jurisdiction-tag house style.

```markdown
- [Get Up to Code](https://getuptocode.com) - **[🇺🇸 US]** Automated website-level compliance scanner (ADA/WCAG accessibility, CCPA and US state privacy, FTC rules, security headers, image copyright) for US small businesses; free scan returns a risk score, $5 full report.
```

**Disclosures, both up front:**

1. **I'm affiliated** — I work on this product. Happy for you to move, reword or decline the entry.
2. **Sibling product already listed** — this is the same company and scanning engine as [TrustYourWebsite](https://trustyourwebsite.com), which you merged in #35 with an `[🇪🇺 EU]` tag. This is the complementary **US** entry, not a duplicate: different jurisdiction (ADA/WCAG, CCPA and US state privacy law, FTC rules vs. GDPR/ePrivacy/EAA), different domain, different pricing in USD. If you'd rather carry only one entry per company, I'd understand — say the word and I'll close this.

No paid placement, no affiliate links. Commit is DCO signed-off.
