### PR TITLE
Skip link report issue when issues are disabled

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -71,7 +71,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create issue from scheduled run
-        if: github.event_name == 'schedule' && steps.lychee.outputs.exit_code != '0'
+        if: >-
+          github.event_name == 'schedule' &&
+          github.event.repository.has_issues &&
+          steps.lychee.outputs.exit_code != '0'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: 'Link Check Report - broken links found'


### PR DESCRIPTION
## Summary

- skip scheduled link-report issue creation when repository Issues are disabled
- preserve the current broken-link report behavior for repositories where Issues are enabled

## Root cause

The scheduled link check deliberately runs Lychee with `fail: false` and then creates an issue when broken links are found. Forks can have Issues disabled; in that case `peter-evans/create-issue-from-file` fails the otherwise successful reporting workflow with `Issues has been disabled in this repository`.

The workflow event already exposes the repository's `has_issues` setting, so the issue step can be gated without suppressing the link report or changing upstream behavior.

## Validation

- parsed `.github/workflows/link-check.yml` successfully as YAML
- `git diff --check` passes
- confirmed `has_issues: false` on the reproducing fork and `has_issues: true` upstream
