### PR TITLE
Add ca-child-support-guideline (open source, California Family Code 4055)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ Organizations and software actively using technology to advance access to justic
 - [World Justice Project Rule of Law Index](https://worldjusticeproject.org/rule-of-law-index/) - **[Nonprofit]** Annual data series measuring rule of law across 143 jurisdictions (95% of world population).
 - [HiiL (Hague Institute for Innovation of Law)](https://www.hiil.org/) - **[Nonprofit]** Justice Accelerator (110+ startups funded since 2011), Justice Innovation Labs, and people-centred justice research.
 - [Clarvia](https://github.com/clarvia-org/clarvia-graph) - **[Open Source]** Free, open-source bereavement compliance checklist for European families. Source-backed legal deadlines, multilingual, structured as a knowledge graph.
+- [ca-child-support-guideline](https://github.com/hayleyhenning90/ca-child-support-guideline) - **[Open Source]** **[🇺🇸 US, California]** Zero-dependency TypeScript library implementing California's statewide child support guideline formula (Family Code 4055), with unit tests covering each statutory income band. Used in production by the free Virdix California Child Support Calculator.
 
 ## Foundational Research
 


### PR DESCRIPTION
Adds ca-child-support-guideline to Access to Justice & Public Interest Tech.

What it is: a small, zero-dependency TypeScript library implementing California's statewide child support guideline formula (Family Code section 4055). MIT licensed, with unit tests covering the low income adjustment band and the other statutory income brackets.

https://github.com/hayleyhenning90/ca-child-support-guideline

Why it fits: open source with real, tested code (meets the "Open source" inclusion criterion), and it is regional coverage not currently in the list (California family law calculation, distinct from the general Consumer Legal Services entries).

Disclosure: I'm the author of both this library and Virdix (a California divorce document prep service that uses the formula in its free child support calculator, linked from the library's README). Happy to adjust wording, placement, or drop the PR if it's not the right fit for the list.