### PR TITLE
Add SquarePact to Document Automation & Drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,7 +1019,7 @@ Software for generating, assembling, and reviewing legal documents.
 - [Accord Project Template Archive](https://github.com/accordproject/template-archive) - **[Open Source]** Smart legal contracts and templating system (Cicero / Concerto).
 - [Gavel (formerly Documate)](https://www.gavel.io/) - **[Established]** No-code document automation + online legal product builder used to ship apps in estate planning, family law, real estate, probate, and immigration.
 - [Renamer.ai](https://renamer.ai) - **[AI-Native]** OCR-based file renaming for legal, contract, and HR documents - reads each file's contents and writes a descriptive, content-aware filename in place of scans and generic names.
-
+- [SquarePact](https://squarepact.com) - **[AI-Native]** Agentic AI drafting and review add-in for Microsoft Word focused on mechanical errors in AI-edited documents — formatting drift, scrivener's errors, mismatched defined terms — with a bring-your-own-agent option that runs on the user's own local agent or API keys.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Adds SquarePact, a Microsoft Word add-in for agentic AI drafting and review of high-stakes documents, to Document Automation & Drafting.

## Inclusion criterion

- [x] Category-defining
- [ ] Open source (link to repo with meaningful code)
- [ ] Significant scale ($100M+ funding or widely adopted)
- [x] Unique technical approach
- [ ] Regional representation (geography/language not yet covered)
- [ ] Academic / research value (peer-reviewed dataset, model, or benchmark)

## Checklist

- [x] Entry is actively maintained (OSS: activity in past 18 months; commercial: live and publicly accessible).
- [x] Description is neutral and factual — no marketing copy, no superlatives.
- [x] Formatting matches the surrounding section (em dash separator, region tags where applicable).
- [x] Not a duplicate of an existing entry.
- [x] Link-check passes (the CI job will tell you).

## Notes for reviewers

Disclosure: I work on SquarePact. Placed in Document Automation & Drafting rather than CLM because it is a drafting/review add-in, not lifecycle management. On distinctness from existing entries: unlike the drafting assistants in this section (Spellbook), it targets the mechanical errors introduced when AI-generated text lands in Word, and unlike post-hoc integrity checking (Recensa), it fixes issues agentically inside the document; the bring-your-own-agent architecture — the add-in can run entirely on the user's own local agent or API keys — is not present in other listed commercial tools. Also emailed contact@vaquill.ai with this suggestion before opening the PR.