### PR TITLE
Add ShareSentry local document inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,7 @@ Platforms for collecting, processing, reviewing, and producing electronically st
 - [IPRO](https://ipro.com) - **[Established]** E-discovery software for large-scale review and production.
 - [FreeEed](https://freeeed.org) - **[Open Source]** AI-enabled e-discovery with OCR and metadata extraction.
 - [FreeEed](https://freeeed.org) - **[Open Source]** AI-enabled cross-platform e-discovery platform with text extraction, metadata processing, and OCR.
+- [ShareSentry](https://github.com/nap6281-hub/sharesentry) - **[Open Source]** Local document inspector that reports hidden metadata and review artifacts in PDF, DOCX, XLSX, PPTX, and image files without uploading source documents.
 
 ---
 


### PR DESCRIPTION
Adds ShareSentry to the E-Discovery & Document Review section.

ShareSentry meets the catalog's open-source and unique-technical-approach criteria: it is an actively maintained MIT-licensed implementation, scans common legal-document formats locally without uploading source files, and emits JSON, SARIF, HTML evidence, and signed reports. The entry is intentionally concise and factual.

Repository: https://github.com/nap6281-hub/sharesentry