### PR TITLE
Add shakalakaa Compliance Rule Sets to Compliance & RegTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
 - [TrustYourWebsite](https://trustyourwebsite.com) - **[🇪🇺 EU]** Automated website-level compliance scanner (GDPR, cookie consent, accessibility, legal pages) for EU and UK small businesses; free scan returns a risk score and issue counts.
 - [EU AI Act Check](https://i6eal.de/eu-ai-act-check/) - **[🇩🇪 DE]** Free, German-language in-browser self-check that classifies an AI system into the EU AI Act risk classes (prohibited, high-risk, limited, minimal) and lists the resulting obligations; no signup, not legal advice.
+- [shakalakaa Compliance Rule Sets](https://github.com/shakalakaa-plixitt/compliance-rules) - **[Open Dataset]** Free, machine-readable JSON healthcare/advertising compliance rules for Malaysia, Singapore, Australia, Hong Kong and Taiwan (MOH/HCSA, AHPRA, PDPA-DNC, KKM/MMC, MDC, TFDA, moneylending-advertising rules), 10 rule sets. Each rule carries its own `source_url`/`source_note` disclosing whether it's verified against a primary regulator or left honestly `null`. CC BY 4.0.
 
 ---
 


### PR DESCRIPTION
[shakalakaa Compliance Rule Sets](https://github.com/shakalakaa-plixitt/compliance-rules) — a free, open (CC BY 4.0) machine-readable JSON dataset of healthcare and advertising compliance rules across Malaysia, Singapore, Australia, Hong Kong and Taiwan (MOH/HCSA, AHPRA, PDPA-DNC, KKM/MMC, MDC, TFDA, and moneylending-advertising rules — 10 rule sets total).

Each individual rule carries its own `source_url`/`source_note` disclosing whether it's independently verified against a primary regulator this review cycle, or left honestly `null` when no stable primary source was found — not a blanket file-level sourcing claim. Tagged **[Open Dataset]** to match the section's existing tag conventions ([AI-Native]/[Established]/[Open / Academic]/[🇪🇺 EU] etc.).

Happy to adjust placement or wording to fit house style.