### PR TITLE
Add kvasir (DE/AT/CH/EU) to MCP Servers for Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Domain-specific encoder models for legal text similarity, classification, and re
 - [Yargı MCP](https://github.com/saidsurucu/yargi-mcp) - **[🇹🇷 Turkey]** MCP server for Turkish legal databases (Yargıtay, Danıştay, Anayasa Mahkemesi).
 - [MCP Taiwan Legal DB](https://github.com/lawchat-oss/mcp-taiwan-legal-db) - **[🇹🇼 Taiwan]** Taiwan Judicial Yuan judgments + national statute database via MCP.
 - [ayunis-legal-mcp](https://github.com/ayunis-core/ayunis-legal-mcp) - **[🇩🇪 Germany]** MCP server exposing German legal codes (Gesetze-im-Internet).
+- [kvasir](https://github.com/kvasir-legal/kvasir-mcp) - **[🇩🇪 🇦🇹 🇨🇭 🇪🇺 DACH/EU]** Hosted MCP server over German federal and state law (Bavaria, NRW, Saxony, Brandenburg, Bremen), Austrian, Swiss and EU law — case law and citation edges, checked daily.
 - [Pasal MCP](https://github.com/ilhamfp/pasal) - **[🇮🇩 Indonesia]** MCP + REST + web app giving AI grounded access to 40k+ Indonesian regulations.
 - [auslaw-mcp](https://github.com/russellbrenner/auslaw-mcp) - **[🇦🇺 🇳🇿 AU/NZ]** MCP server searching AustLII case law and legislation with OCR for scanned PDFs.
 - [law-scrapper-mcp](https://github.com/numikel/law-scrapper-mcp) - **[🇵🇱 Poland]** MCP server for Polish legal acts via the Sejm API.


### PR DESCRIPTION
## What this PR does

Adds kvasir to *MCP Servers for Legal*: a hosted MCP server over German federal
and state law, Austrian, Swiss and EU law, with citation verification against the
official sources.

## Inclusion criterion

- [ ] Category-defining
- [ ] Open source (link to repo with meaningful code)
- [ ] Significant scale ($100M+ funding or widely adopted)
- [x] Unique technical approach
- [x] Regional representation (geography/language not yet covered)
- [ ] Academic / research value (peer-reviewed dataset, model, or benchmark)

## Checklist

- [x] Entry is actively maintained (OSS: activity in past 18 months; commercial: live and publicly accessible).
- [x] Description is neutral and factual — no marketing copy, no superlatives.
- [x] Formatting matches the surrounding section (em dash separator, region tags where applicable).
- [x] Not a duplicate of an existing entry.
- [x] Link-check passes (the CI job will tell you).

## Notes for reviewers

**Unique technical approach:** every other entry in this section retrieves. This
one adds the inverse operation — `check_draft` and `verify_citations` take the
citations a model *produced* and check them against the corpus: existence, quoted
wording, and whether the provision is still in force. Deterministic lookups
against canonical objects, no second model judging the first. That is the failure
mode the section note at the end warns about. Sub-units are addressable down to
the sentence, and citations are stored as ten distinct typed edge types rather
than one generic "cites" relation.

**Regional representation:** Austria is not covered anywhere in the list today,
and no entry covers German *state* law — `ayunis-legal-mcp` serves federal
Gesetze-im-Internet only. This adds Bavaria, NRW, Saxony, Brandenburg and Bremen
alongside Austria (OGH, VfGH, VwGH) and Switzerland.

**Not a duplicate:** distinct from `ayunis-legal-mcp` (federal statutes only, no
case law, no verification) and from `Emilie` (a Swiss assistant with a local
model, not a law corpus).

Corpus figures are live at https://kvasir.legal/api/v1/status; per-source rights
and update cadence at https://kvasir.legal/sources.