### PR TITLE
Add OKF-Legal to Standards & Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,6 +1286,7 @@ Open standards and specifications relevant to legal technology and AI integratio
 - [LEDES (Legal Electronic Data Exchange Standard)](https://ledes.org) - Standard formats for legal billing (e-billing).
 - [EU AI Act](https://artificialintelligenceact.eu) - World's first comprehensive AI regulation law. In force Aug 2024; full applicability Aug 2026. Directly impacts legal AI tools.
 - [LegalXML / OASIS LegalDocML](https://docs.oasis-open.org/legaldocml/) - XML schema standard for legal documents (bills, statutes, regulations). Used by parliaments globally.
+- [OKF-Legal](https://github.com/apiotrowski-afk/okf-legal) - **[🇵🇱 Poland]** Legal-domain profile over Google's Open Knowledge Format: markdown+YAML sub-document units ("directed reasons") for case-law holdings, carrying a verbatim quote, direction, ratio/obiter status, and source court instance, plus typed relations and anti-hallucination consumption rules. Distilled from a ~1,100-judgment Polish case-law corpus. Apache 2.0.
 - [EDRM (Electronic Discovery Reference Model)](https://edrm.net) - Industry standard framework for e-discovery workflows, data models, and specifications.
 
 ---


### PR DESCRIPTION
Adds [OKF-Legal](https://github.com/apiotrowski-afk/okf-legal), a legal-domain profile over Google's Open Knowledge Format (OKF): markdown+YAML sub-document units ("directed reasons") for case-law holdings, with a verbatim source quote, direction (which side an argument favors), ratio/obiter status, source court instance, plus typed relations and anti-hallucination consumption rules (quote verification, a confidence floor, statistics that must carry sample size and time window).

Distilled from two independent production systems by the same author: a ~1,100-judgment Polish case-law corpus (~135k reasoning atoms) and the contract-drafting skill already listed in this repo ([commercial-legal-pl](https://github.com/apiotrowski-afk/commercial-legal-pl), Agent Skills section).

Open source (Apache 2.0), actively developed (multiple commits this week), English spec at [SPEC.en.md](https://github.com/apiotrowski-afk/okf-legal/blob/main/SPEC.en.md).