### PR TITLE
Add CaseValue.law to Consumer Legal Services (B2C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Platforms delivering direct-to-consumer automated legal services, documents, and
 - [Wealth.com](https://www.wealth.com/) - **[AI-Native]** Estate-planning platform for RIAs/wirehouses with "Ester" AI doc extraction; underpins wealth managers running >$15T AUM.
 - [SoloSuit](https://www.solosuit.com/) - **[AI-Native]** "TurboTax for debt-collection lawsuits" — auto-drafts answers and runs SoloSettle negotiations; has helped 350,000+ Americans protect $2.5B+ in debt.
 - [Aricase](https://aricase.ai) - **[AI-Native]** 🇬🇧 Employment-tribunal case-builder (England & Wales): guidance, document drafting and next steps, with a human quality check.
+- [CaseValue.law](https://casevalue.law) - **[AI-Native]** Free settlement-value estimator for 16 injury and employment claim types across all 50 states; its Lowball Detector reads an insurance settlement offer letter and compares the offer to the estimate.
 
 ---
 


### PR DESCRIPTION
Adds CaseValue.law to Consumer Legal Services (B2C), alongside the other direct-to-consumer self-help tools (DoNotPay, SoloSuit, Aricase).

Why it belongs (unique technical approach): it computes a settlement-value estimate from each state's own rules (statute of limitations, comparative-negligence system, damage caps) across 16 claim types and all 50 states plus DC, and its Lowball Detector uses a multimodal model to read an insurance settlement offer letter and compare the offer to that computed estimate. That offer-vs-estimate comparison is uncommon among the B2C tools currently listed.

Meets the minimum bar: free, no signup, actively maintained, publicly accessible, verifiable at https://casevalue.law, described neutrally, and distinct from existing entries.

Entry added to the Consumer Legal Services (B2C) section:

    - [CaseValue.law](https://casevalue.law) - **[AI-Native]** Free settlement-value estimator for 16 injury and employment claim types across all 50 states; its Lowball Detector reads an insurance settlement offer letter and compares the offer to the estimate.
