### PR TITLE
Add MiCAR Whitepaper Linter to Compliance & RegTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,7 @@ Tools for regulatory compliance, policy management, financial crime detection, a
 - [Climate Case Chart](https://www.climatecasechart.com/) - **[Open / Academic]** Sabin Center + Arnold & Porter database of 2,600+ US and global climate-change cases across 54 jurisdictions, updated monthly.
 - [Persefoni](https://www.persefoni.com/) - **[AI-Native]** "ERP of carbon" climate-accounting platform supporting CSRD, SEC climate rule, TCFD, and CDP disclosures for enterprises and financial institutions.
 - [TrustYourWebsite](https://trustyourwebsite.com) - **[🇪🇺 EU]** Automated website-level compliance scanner (GDPR, cookie consent, accessibility, legal pages) for EU and UK small businesses; free scan returns a risk score and issue counts.
+- [MiCAR Whitepaper Linter](https://github.com/sebastianfoerste/micar-whitepaper-linter) - **[🇪🇺 EU]** Deterministic linter for crypto-asset white papers under MiCAR (EU) 2023/1114: 35 rules mapped to Annex I-III with pinpoint citations, a CI action, and a browser playground.
 - [EU AI Act Check](https://i6eal.de/eu-ai-act-check/) - **[🇩🇪 DE]** Free, German-language in-browser self-check that classifies an AI system into the EU AI Act risk classes (prohibited, high-risk, limited, minimal) and lists the resulting obligations; no signup, not legal advice.
 
 ---


### PR DESCRIPTION
Resubmission of #57, which was auto-closed in July when the head fork was deleted during a profile cleanup — not withdrawn for review reasons, and it received no review feedback.

Adds [micar-whitepaper-linter](https://github.com/sebastianfoerste/micar-whitepaper-linter) to **Compliance & RegTech**.

**What it is:** a deterministic Python linter for crypto-asset white paper drafts under MiCAR (Regulation (EU) 2023/1114). 35 rules mapped to Annex I, II and III with stable rule IDs and pinpoint citations; outputs cited findings, remediation reports, and review bundles. Synthetic examples; explicitly not legal advice.

**Since the original PR:** relicensed MIT; a GitHub Action (`@v1`) for CI linting; a [browser playground](https://sebastianfoerste.github.io/micar-whitepaper-linter/playground/) — try it with no install; a reproducible study over real ESMA-register filings with a human-review worksheet.

**Inclusion criteria mapping:** *unique technical approach* (to my knowledge the only public regulation-as-code linter for MiCAR white papers; every finding carries a pinpoint Annex citation), *regional representation* (EU crypto-asset regulation, not otherwise covered in the section), and the minimum bar: actively maintained, verifiable, runnable via `make install && make test && make demo`, CI green.

**Disclosure:** I am the author — a German-qualified lawyer practicing EU financial regulation; the rule-to-Annex mapping is hand-authored.