### PR TITLE
Add CairnVault Research digital-legacy teardown (Access to Justice & Public Interest Tech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,7 @@ Organizations and software actively using technology to advance access to justic
 - [HiiL (Hague Institute for Innovation of Law)](https://www.hiil.org/) - **[Nonprofit]** Justice Accelerator (110+ startups funded since 2011), Justice Innovation Labs, and people-centred justice research.
 - [Clarvia](https://github.com/clarvia-org/clarvia-graph) - **[Open Source]** Free, open-source bereavement compliance checklist for European families. Source-backed legal deadlines, multilingual, structured as a knowledge graph.
 - [Elder Fraud Toolkit](https://github.com/stepuplaw/elder-fraud-toolkit) - **[Open Source]** MIT credit-freeze letter generator covering all three US bureaus, including the power-of-attorney and guardianship route. Runs entirely in-browser with zero network calls.
+- [CairnVault Research - Digital Legacy Teardown](https://research.cairnvault.app/digital-legacy-teardown/) - **[Open Source]** Sourced comparison of what every major password manager, platform legacy-contact feature and digital-legacy service actually does when a user dies, with each claim cited to the vendor's own documentation. Includes a 46-question answer library covering RUFADAA and platform policy, a CC BY 4.0 dataset ([DOI 10.5281/zenodo.21894423](https://doi.org/10.5281/zenodo.21894423)), and a dated public correction log.
 
 ## Foundational Research
 


### PR DESCRIPTION
### What this adds

One entry under **Access to Justice & Public Interest Tech**: an open, primary-source research corpus on what actually happens to a person's online accounts, passwords and photos when they die.

- Comparison of every major password manager, platform legacy-contact feature and commercial digital-legacy service, with each claim cited to the vendor's own live documentation rather than to a summary.
- A 46-question answer library covering RUFADAA adoption, platform policy and the criminal-law questions around accessing a deceased person's accounts.
- The underlying data as CC BY 4.0, archived with a DOI: https://doi.org/10.5281/zenodo.21894423
- A dated, public correction log. Claims that turned out to be wrong are quoted in place and corrected rather than deleted — the most recent correction credits a Bitwarden forum member who found a real error in the comparison.

### Disclosure

I should be straightforward about the conflict of interest, because it is relevant to whether you want this: **I work on CairnVault, which sells a commercial product in this category.** That is disclosed at the top of every page of the research itself, and it is the reason every claim is sourced to somebody else's documentation instead of ours. The linked material is the research corpus, not the product — it is CC BY 4.0, contains no pricing or signup, and the comparison includes findings that run against our own product's design trade-offs.

If a vendor-published resource is not something you want in the list even when it is openly licensed and sourced, that is a completely reasonable call and I would rather you close this than stretch the criteria.

### Why it belongs here

Nearest existing neighbours are [Clarvia](https://github.com/clarvia-org/clarvia-graph) (bereavement compliance checklist) and the [Elder Fraud Toolkit](https://github.com/stepuplaw/elder-fraud-toolkit) — both sourced, openly-licensed reference resources for people dealing with death and incapacity rather than SaaS products. This covers the adjacent gap: the digital-asset side of the same problem.

Against the inclusion criteria it meets **Open source** (public repos under https://github.com/cairnvault, CC BY 4.0) and, arguably, **Academic / research value** (open dataset with a DOI). It is not a blog or an opinion piece — it is a sourced corpus with a citation file and a correction policy.

### Formatting

Matches the section's existing shape: `- [Name](url) - **[Open Source]** description.`, two sentences, neutral, no superlatives. I linked the published research site rather than the repo because that is the readable artifact; the repos are the build source. Happy to switch it to the GitHub link if you prefer the convention held strictly — just say so.

Not legal advice, and the research says so on every page.