### PR TITLE
Add OpenAgreements to Document Automation & Drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ Software for generating, assembling, and reviewing legal documents.
 - [Docassemble](https://docassemble.org) - **[Open Source]** The gold standard target for guided legal interviews and document assembly.
 - [Suffolk LIT Lab Assembly Line](https://github.com/SuffolkLITLab/docassemble-AssemblyLine) - **[Open Source]** Toolkit for Massachusetts court forms; reusable pattern for any jurisdiction.
 - [open-agreements](https://github.com/CommonAccord/Cmacc-Org) - **[Open Source]** CommonAccord: legal documents as structured, linkable data.
+- [OpenAgreements](https://github.com/open-agreements/open-agreements) - **[Open Source]** Standard agreement templates, primary-source-backed U.S. legal guides, surveys, and review checklists, with CLI and MCP tools for producing reviewable Word documents.
 - [adeu](https://github.com/dealfluence/adeu) - **[Open Source]** Agentic DOCX Redlining Engine for Word document Track Changes.
 - [deslop](https://github.com/fayerman-source/deslop) - **[Open Source]** Portable AI agent skill that rewrites legalese into plain English while preserving binding terms of art.
 - [Vaquill AI for Word](https://github.com/Vaquill-AI/vaquill-word-addin) - **[Open Source]** Microsoft Word task-pane add-in for contract review, grounded redlining as native tracked changes, drafting, and US legal research. A community build runs standalone on your own OpenAI or Anthropic key. Apache-2.0. *(Sponsor)*


### PR DESCRIPTION
Add OpenAgreements to Document Automation & Drafting.

OpenAgreements publishes standard agreement templates, primary-source-backed U.S. legal guides, comparison surveys, and review checklists, with CLI and MCP tools for filling templates into reviewable DOCX files. The project code is Apache-2.0 licensed; content retains its source-specific licenses.

- Repository: https://github.com/open-agreements/open-agreements
- Project: https://openagreements.org/
- Usage and scope: https://github.com/open-agreements/open-agreements/blob/main/README.md

This adds the project alongside the existing CommonAccord entry, whose link points to `CommonAccord/Cmacc-Org`. They are separate projects.

The addition matches the section's existing format and the open-source inclusion criterion. Verified the public repository, documented CLI/MCP workflow, recent development activity, and absence of an existing entry linking to this repository. `git diff --check` passes.

Disclosure: we maintain OpenAgreements.
